### PR TITLE
Add NRPE check for rabbitmq queues into contrail-controller

### DIFF
--- a/contrail-controller/config.yaml
+++ b/contrail-controller/config.yaml
@@ -190,3 +190,31 @@ options:
     description: |
       A comma-separated list of nagios servicegroups.
       If left empty, the nagios_context will be used as the servicegroup
+  stats_cron_schedule:
+    type: string
+    default: '*/5 * * * *'
+    description: |
+      Cron schedule used to generate rabbitmq stats. To disable,
+      either unset this config option or set it to an empty string ('').
+  cron-timeout:
+    type: int
+    default: 300
+    description: |
+      Run a command with a time limit specified in seconds in cron.
+      This timeout will govern to the rabbitmq stats capture, and that once
+      the timeout is reached a SIGINT is sent to the program, if it doesn't
+      exits before 10 seconds a SIGKILL is sent.
+  queue_thresholds:
+    type: string
+    default: "[['\\*', '\\*', 500, 1000]]"
+    description: |
+      List of RabbitMQ queue size check thresholds. Interpreted as YAML in
+      format [<vhost>, <queue>, <warn>, <crit>]
+      Per-queue thresholds can be expressed as a multi-line YAML array:
+      - ['/', 'queue1', 10, 20]
+      - ['/', 'queue2', 200, 300]
+      Or as a list of lists:
+      [['/', 'queue1', 10, 20], ['/', 'queue2', 200, 300]]
+      Wildcards '*' are accepted to monitor all vhosts and/or queues.
+      In case of multiple matches, only the first will apply: wildcards should
+      therefore be used last in order to avoid unexpected behavior.

--- a/contrail-controller/files/collect_rabbitmq_stats.sh
+++ b/contrail-controller/files/collect_rabbitmq_stats.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (C) 2011, 2014, 2020 Canonical
+# All Rights Reserved
+# Author: Liam Young, Jacek Nykis, Peter Sabaini
+
+# Produce a queue data for a given vhost. Useful for graphing and Nagios checks
+LOCK=/var/lock/rabbitmq-gather-metrics.lock
+# Check for a lock file and if not, create one
+lockfile-create -r2 --lock-name $LOCK > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Failed to create lockfile: $LOCK."
+    exit 1
+fi
+trap "rm -f $LOCK > /dev/null 2>&1" exit
+
+# Required to fix the bug about start-stop-daemon not being found in
+# rabbitmq-server 2.7.1-0ubuntu4.
+# '/usr/sbin/rabbitmqctl: 33: /usr/sbin/rabbitmqctl: start-stop-daemon: not found'
+export PATH=${PATH}:/sbin/
+
+RABBIT_CONTAINER=$( docker ps |awk '/rabbitmq/{ print $10 }' )
+
+DATA_DIR="/var/lib/misc/rabbitmq-check"
+DATA_FILE="${DATA_DIR}/rabbitmq_queue_stats.dat"
+LOG_DIR="$DATA_DIR/logs"
+RABBIT_STATS_DATA_FILE="${DATA_DIR}/rabbitmq_general_stats.dat"
+NOW=$(date +'%s')
+HOSTNAME=$(hostname -s)
+
+rabbit_docker() {
+  docker exec $RABBIT_CONTAINER bash -c "$@"
+}
+
+MNESIA_DB_SIZE=$( rabbit_docker 'du -sm /var/lib/rabbitmq/mnesia | cut -f1' )
+RABBIT_RSS=$( rabbit_docker 'ps -p $( pgrep -f "[b]eam.*rabbit") -o rss=' )
+
+mkdir -p $DATA_DIR $LOG_DIR
+
+TMP_DATA_FILE=$(mktemp -p ${DATA_DIR})
+echo "#Vhost Name Messages_ready Messages_unacknowledged Messages Consumers Memory Time" > ${TMP_DATA_FILE}
+rabbit_docker '/opt/rabbitmq/sbin/rabbitmqctl -q --no-table-headers list_vhosts' | \
+while read VHOST; do
+    rabbit_docker "/opt/rabbitmq/sbin/rabbitmqctl -q --no-table-headers list_queues -p $VHOST name messages_ready messages_unacknowledged messages consumers memory" | \
+    awk "{print \"$VHOST \" \$0 \" $(date +'%s') \"}" >> ${TMP_DATA_FILE} 2>${LOG_DIR}/list_queues.log
+done
+mv ${TMP_DATA_FILE} ${DATA_FILE}
+chmod 644 ${DATA_FILE}
+echo "mnesia_size: ${MNESIA_DB_SIZE}@$NOW" > $RABBIT_STATS_DATA_FILE
+echo "rss_size: ${RABBIT_RSS}@$NOW" >> $RABBIT_STATS_DATA_FILE

--- a/contrail-controller/files/plugins/check_rabbitmq_queues.py
+++ b/contrail-controller/files/plugins/check_rabbitmq_queues.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+# Copyright (C) 2011, 2012, 2014, 2020 Canonical
+# All Rights Reserved
+# Author: Liam Young, Jacek Nykis, Peter Sabaini
+
+from collections import defaultdict
+from fnmatch import fnmatchcase
+from itertools import chain
+import argparse
+import sys
+
+
+def gen_data_lines(filename):
+    with open(filename, "rt") as fin:
+        for line in fin:
+            if not line.startswith("#"):
+                yield line
+
+
+def gen_stats(data_lines):
+    for line in data_lines:
+        try:
+            vhost, queue, _, _, m_all, _ = line.split(None, 5)
+        except ValueError:
+            print("ERROR: problem parsing the stats file")
+            sys.exit(2)
+        assert m_all.isdigit(), ("Message count is not a number: {0!r}"
+                                 .format(m_all))
+        yield vhost, queue, int(m_all)
+
+
+def collate_stats(stats, limits):
+    # Create a dict with stats collated according to the definitions in the
+    # limits file. If none of the definitions in the limits file is matched,
+    # store the stat without collating.
+    collated = defaultdict(lambda: 0)
+    for vhost, queue, m_all in stats:
+        for l_vhost, l_queue, _, _ in limits:
+            if fnmatchcase(vhost, l_vhost) and fnmatchcase(queue, l_queue):
+                collated[l_vhost, l_queue] += m_all
+                break
+        else:
+            collated[vhost, queue] += m_all
+    return collated
+
+
+def check_stats(stats_collated, limits):
+    # Create a limits lookup dict with keys of the form (vhost, queue).
+    limits_lookup = dict(
+        ((l_vhost, l_queue), (int(t_warning), int(t_critical)))
+        for l_vhost, l_queue, t_warning, t_critical in limits)
+    if not (stats_collated):
+        yield 'No Queues Found', 'No Vhosts Found', None, "UNKNOWN"
+    # Go through the stats and compare again limits, if any.
+    for l_vhost, l_queue in sorted(stats_collated):
+        m_all = stats_collated[l_vhost, l_queue]
+        try:
+            t_warning, t_critical = limits_lookup[l_vhost, l_queue]
+        except KeyError:
+            yield l_queue, l_vhost, m_all, "UNKNOWN"
+        else:
+            if m_all >= t_critical:
+                yield l_queue, l_vhost, m_all, "CRIT"
+            elif m_all >= t_warning:
+                yield l_queue, l_vhost, m_all, "WARN"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='RabbitMQ queue size nagios check.')
+    parser.add_argument(
+        '-c',
+        nargs=4,
+        action='append',
+        required=True,
+        metavar=('vhost', 'queue', 'warn', 'crit'),
+        help=('Vhost and queue to check. Can be used multiple times'))
+    parser.add_argument(
+        'stats_file',
+        nargs='*',
+        type=str,
+        help='file containing queue stats')
+    args = parser.parse_args()
+
+    # Start generating stats from all files given on the command line.
+    stats = gen_stats(
+        chain.from_iterable(
+            gen_data_lines(filename) for filename in args.stats_file))
+    # Collate stats according to limit definitions and check.
+    stats_collated = collate_stats(stats, args.c)
+    stats_checked = check_stats(stats_collated, args.c)
+    criticals, warnings = [], []
+    for queue, vhost, message_no, status in stats_checked:
+        if status == "CRIT":
+            criticals.append(
+                "%s in %s has %s messages" % (queue, vhost, message_no))
+        elif status == "WARN":
+            warnings.append(
+                "%s in %s has %s messages" % (queue, vhost, message_no))
+    if len(criticals) > 0:
+        print("CRITICAL: {}".format(", ".join(criticals)))
+        sys.exit(2)
+        # XXX: No warnings if there are criticals?
+    elif len(warnings) > 0:
+        print("WARNING: {}".format(", ".join(warnings)))
+        sys.exit(1)
+    else:
+        print("OK")
+        sys.exit(0)

--- a/contrail-controller/hooks/common_utils.py
+++ b/contrail-controller/hooks/common_utils.py
@@ -29,6 +29,7 @@ from charmhelpers.core.host import (
 from charmhelpers.core.templating import render
 
 config = config()
+SCRIPTS_DIR = '/usr/local/bin'
 
 
 def get_ip(config_param="control-network", fallback=None):
@@ -303,6 +304,16 @@ def rsync_nrpe_checks(plugins_dir):
                                     'plugins/')
     rsync(charm_plugin_dir,
           plugins_dir,
+          options=['--executability'])
+
+
+def rsync_script(script_file):
+    charm_script = os.path.join(charm_dir(),
+                                'files',
+                                script_file
+    )
+    rsync(charm_script,
+          SCRIPTS_DIR,
           options=['--executability'])
 
 

--- a/contrail-controller/hooks/docker_utils.py
+++ b/contrail-controller/hooks/docker_utils.py
@@ -21,7 +21,7 @@ config = config()
 DOCKER_ADD_PACKAGES = ["docker-compose"]
 DOCKER_CLI = "/usr/bin/docker"
 DOCKER_COMPOSE_CLI = "docker-compose"
-
+EXTRA_PACKAGES = ["lockfile-progs"]
 
 def _format_curl_https_proxy_opt():
     proxy_settings = env_proxy_settings(['https'])
@@ -68,6 +68,7 @@ def install():
     apt_update()
     apt_install(docker_package)
     apt_install(DOCKER_ADD_PACKAGES)
+    apt_install(EXTRA_PACKAGES)
     _render_config()
     _apply_insecure()
     _login()


### PR DESCRIPTION
The rabbitmq queue check periodically checks for stuck messages in
queues. It's adapated from the openstack charm-rabbitmq-server checks
to work with the dockerized contrail-controller rabbitmq